### PR TITLE
Error on execute, bad if condition

### DIFF
--- a/get_environment_commit.sh
+++ b/get_environment_commit.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
  
-if (( $# != 1 )); then
+if [ $# -eq 1 ]; then
   echo "Call this script with the name of the environment"
   echo "Example: ${0} production"
   exit 1


### PR DESCRIPTION
Error when executing, get_environment_commit.sh: 3: get_environment_commit.sh: 1: not found

In shell script :
!= == is to compare with string while -ne -eq -le -lt -ge -gt are to compare integer
(( is to do mathematical operation while [ ]  [[ ]] are to do if statement.  

This revision fix the error on the line and display as expected:

root@roy-bodden:/# get_environment_commit.sh
Call this script with the name of the environment
Example: ../scripts/get_environment_commit.sh production

root@roy-bodden:/# get_environment_commit.sh development
9f3467f